### PR TITLE
Avoid temp config file by using new version of appdmg

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,21 +25,22 @@ module.exports = function (grunt) {
 
     // Before generating any new files, remove any previously-created files.
     clean: {
-      tests: ['.tmp']
+      tests: ['test/.tmp']
     },
 
     // Configuration to be run (and then tested).
     appdmg: {
       options: {
+        basepath: 'test/fixtures/',
         title: '<%= pkg.name %> Test',
-        background: 'test/fixtures/TestBkg.png',
+        background: 'TestBkg.png',
         'icon-size': 80,
         contents: [
           {
             x: 192,
             y: 344,
             type: 'file',
-            path: 'test/fixtures/TestApp.app'
+            path: 'TestApp.app'
           },
           {
             x: 448,
@@ -50,19 +51,19 @@ module.exports = function (grunt) {
         ]
       },
       basic: {
-        dest: '.tmp/basic.dmg'
+        dest: 'test/.tmp/basic.dmg'
       },
       extra: {
-        dest: '.tmp/extra.dmg',
+        dest: 'test/.tmp/extra.dmg',
+
         options: {
-          configFile: '.tmp/appdmg/extra.json',
-          icon: 'test/fixtures/TestIcon.icns',
+          icon: 'TestIcon.icns',
           contents: [
             {
               x: 192,
               y: 344,
               type: 'file',
-              path: 'test/fixtures/TestApp.app'
+              path: 'TestApp.app'
             },
             {
               x: 448,
@@ -74,7 +75,7 @@ module.exports = function (grunt) {
               x: 512,
               y: 128,
               type: 'file',
-              path: 'test/fixtures/TestDoc.txt'
+              path: 'TestDoc.txt'
             }
           ]
         }

--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ grunt.loadNpmTasks('grunt-appdmg');
 
 ### Options
 See the [JSON Specification](https://github.com/LinusU/node-appdmg#json-specification) of node-appdmg.
-Options except for **configFile** follow the spec.
-
-#### configFile
-Type: 'String'  
-Default: `.tmp/appdmg/config.json`
-
-Path to the temporary config file for appdmg task.
 
 ### Example config
 In your project's Gruntfile, add a section named `appdmg` to the data object passed into `grunt.initConfig()`.

--- a/package.json
+++ b/package.json
@@ -36,9 +36,8 @@
     "LICENSE-MIT"
   ],
   "dependencies": {
-    "appdmg": "^0.2.2",
-    "chalk": "^0.5.1",
-    "lodash": "^2.4.1"
+    "appdmg": "^0.3.0",
+    "chalk": "^0.5.1"
   },
   "peerDependencies": {
     "grunt": "^0.4.0"

--- a/tasks/appdmg.js
+++ b/tasks/appdmg.js
@@ -2,12 +2,7 @@
 
 var path = require('path');
 var appdmg = require('appdmg');
-var _ = require('lodash');
 var chalk = require('chalk');
-
-function isAbsolutePath(p) {
-  return path.normalize(p) === path.resolve(p);
-}
 
 module.exports = function (grunt) {
 
@@ -15,39 +10,11 @@ module.exports = function (grunt) {
   // creation: http://gruntjs.com/creating-tasks
   grunt.registerMultiTask('appdmg', 'Generate DMG-images for Mac OSX', function () {
 
-    // Merge task-specific and/or target-specific options with these defaults.
-    var defaults = {
-      configFile: '.tmp/appdmg/config.json'
-    };
-    var options = this.options(defaults);
-    var config;
+    var options = this.options();
     var done = this.async();
 
-    function getConfig(options) {
-      var config = _.cloneDeep(options);
-      var baseDir = path.dirname(options.configFile);
-      var pathProperties = ['icon', 'background'];
-      delete config.configFile;
-
-      // Replace properties with correct relative path
-      // TODO: Cleanup the replacement after app-dmg supports base path or other solution.
-      pathProperties.forEach(function (property) {
-        if (config[property]) {
-          config[property] = path.relative(baseDir, options[property]);
-        }
-      });
-      if (config.contents) {
-        config.contents.forEach(function (contents) {
-          if (isAbsolutePath(contents.path)) { return; }
-          contents.path = path.relative(baseDir, contents.path);
-        });
-      }
-      return config;
-    }
-
-    // Save appdmg config json.
-    config = getConfig(options);
-    grunt.file.write(options.configFile, JSON.stringify(config, null, 2));
+    var basepath = options.basepath || process.cwd();
+    delete options.basepath;
 
     // Iterate over all specified file groups.
     this.files.forEach(function (filePair) {
@@ -60,7 +27,7 @@ module.exports = function (grunt) {
 
       // Run appdmg module.
       // TODO: Remove logging and use native appdmg's method in the future release.
-      emitter = appdmg(options.configFile, filePair.dest);
+      emitter = appdmg({basepath: basepath, specification: options, target: filePair.dest});
       emitter.on('progress', function (info) {
         if (info.type === 'step-begin') {
           var line =  '[' + (info.current <= 9 ? ' ' : '') + info.current + '/' + info.total + '] ' + info.title + '...';

--- a/test/appdmg_test.js
+++ b/test/appdmg_test.js
@@ -31,22 +31,16 @@ exports.appdmg = {
   },
 
   basic: function (test) {
-    test.expect(2);
-    var exists = fs.existsSync('.tmp/basic.dmg');
-    var actual = grunt.file.read('.tmp/appdmg/config.json');
-    var expected = grunt.file.read('test/expected/config.json');
+    test.expect(1);
+    var exists = fs.existsSync('test/.tmp/basic.dmg');
     test.ok(exists, 'should create the dmg file with basic option.');
-    test.equal(actual, expected, 'should describe what the behavior of basic option is.');
     test.done();
   },
 
   extra: function (test) {
-    test.expect(2);
-    var exists = fs.existsSync('.tmp/extra.dmg');
-    var actual = grunt.file.read('.tmp/appdmg/extra.json');
-    var expected = grunt.file.read('test/expected/extra.json');
+    test.expect(1);
+    var exists = fs.existsSync('test/.tmp/extra.dmg');
     test.ok(exists, 'should create the dmg file with extra option.');
-    test.equal(actual, expected, 'should describe what the behavior of extra option is.');
     test.done();
   }
 


### PR DESCRIPTION
The PR removes all the complexity around temp config files.

Paths to resources are now relative to the root of the project.
