### PR TITLE
Lock version to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "appdmg": "^0.3.0",
+    "appdmg": "0.3.2",
     "chalk": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
appdmg 0.3.4 gives 'undefined is not a function' so pin to 0.3.2
