### PR TITLE
Add compatibility for Node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tasks"
   ],
   "dependencies": {
-    "appdmg": "^0.4.5",
+    "appdmg": "^0.6.0",
     "chalk": "^1.0.0",
     "repeat-string": "^1.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "tasks"
   ],
   "dependencies": {
-    "appdmg": "^0.6.0",
+    "appdmg": "^0.5.2 || ^0.6.0",
     "chalk": "^1.0.0",
     "repeat-string": "^1.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-appdmg",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Grunt plugin for generating Mac OS X DMG-images.",
   "author": {
     "name": "Rakuten, Inc."
@@ -23,9 +23,6 @@
   "engines": {
     "node": ">=4"
   },
-  "os": [
-    "darwin"
-  ],
   "scripts": {
     "test": "grunt test --verbose",
     "grunt": "grunt"
@@ -35,9 +32,11 @@
     "tasks"
   ],
   "dependencies": {
-    "appdmg": "^0.5.2 || ^0.6.0",
     "chalk": "^1.0.0",
     "repeat-string": "^1.5.4"
+  },
+  "optionalDependencies": {
+    "appdmg": "^0.5.2 || ^0.6.0"
   },
   "devDependencies": {
     "eslint": "^3.16.1",


### PR DESCRIPTION
Grunt-appdmg currently does not work with Node 12, because appdmg 0.4.5 is not compatible. Version 0.6.0 was updated to solve this problem. This fixes bug #20. 